### PR TITLE
Upgrade TestGrains from Newtonsoft.Json 5.0.8 to 6.0.5.

### DIFF
--- a/src/OrleansHost/app.config
+++ b/src/OrleansHost/app.config
@@ -25,6 +25,10 @@
         <assemblyIdentity name="Microsoft.WindowsAzure.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/TestGrains/packages.config
+++ b/src/TestGrains/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Add a binding redirect to OrleansHost to Newtonsoft.Json 6.0.0.0.
